### PR TITLE
Add new software entries from TODO batch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,16 +13,16 @@ blog/<file.md>
 - [x] 2021-10-09-projects-and-tools.md
 - [x] 2021-10-13-favorite-vs-code-extensions.md
 - [x] 2021-11-14-links-from-my-inbox-november-2021.md
-- [ ] 2021-12-26-links-from-my-inbox-december-2021.md
-- [ ] 2022-03-04-links-from-my-inbox-march.md
-- [ ] 2022-03-19-links-from-my-inbox-march2.md
-- [ ] 2022-04-19-links-from-my-inbox-april-2022.md
-- [ ] 2022-05-21-links-from-my-inbox-may-2022.md
-- [ ] 2022-05-22-links-from-my-inbox-may-2022-part2.md
-- [ ] 2022-06-18-links-from-my-inbox-june-2022.md
-- [ ] 2022-07-22-links-from-my-inbox-july-2022.md
-- [ ] 2022-08-06-links-from-my-inbox-august-2022.md
-- [ ] 2022-09-18-links-from-my-inbox-september-2022.md
+- [x] 2021-12-26-links-from-my-inbox-december-2021.md
+- [x] 2022-03-04-links-from-my-inbox-march.md
+- [x] 2022-03-19-links-from-my-inbox-march2.md
+- [x] 2022-04-19-links-from-my-inbox-april-2022.md
+- [x] 2022-05-21-links-from-my-inbox-may-2022.md
+- [x] 2022-05-22-links-from-my-inbox-may-2022-part2.md
+- [x] 2022-06-18-links-from-my-inbox-june-2022.md
+- [x] 2022-07-22-links-from-my-inbox-july-2022.md
+- [x] 2022-08-06-links-from-my-inbox-august-2022.md
+- [x] 2022-09-18-links-from-my-inbox-september-2022.md
 - [ ] 2022-10-07-links-from-my-inbox-october-2022.md
 - [ ] 2022-11-07-links-from-my-inbox-november-2022.md
 - [ ] 2022-11-13-links-from-my-inbox.md

--- a/software.md
+++ b/software.md
@@ -25,6 +25,21 @@
 - [Yaak](https://yaak.app/) – Fast, offline-first, Git-friendly API client for REST, GraphQL, WebSocket, SSE and gRPC endpoints. Store requests as plain-text files for version control, encrypt secrets locally, and replay or share them from a desktop GUI.
 - [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) – Send HTTP requests directly from VS Code and inspect responses without leaving the editor.
 
+### 🖼️📊 Diagramming & Drawing
+- [drawio-desktop](https://github.com/jgraph/drawio-desktop) – Electron-based diagrams.net app that works offline for creating flowcharts and architecture sketches.
+
+### 🗄️📂 File Managers
+- [far2l](https://github.com/elfmz/far2l) – Modernized port of the classic FAR Manager with terminal and GUI interfaces for Linux and macOS.
+
+### 📝 Markdown Editors
+- [MarkText](https://github.com/marktext/marktext) – Cross-platform Markdown editor with live preview and minimal UI, built on Electron.
+
+### 🌐📡 Networking Utilities
+- [wgcf](https://github.com/ViRb3/wgcf) – Unofficial CLI for Cloudflare Warp that generates WireGuard profiles. `wgcf register && wgcf generate` produces a config ready for `wg-quick`.
+- [bombardier](https://github.com/codesenberg/bombardier) – Fast HTTP(S) benchmarking tool written in Go for stress testing APIs and websites.
+- [dasel](https://github.com/TomWright/dasel) – Query and update JSON, YAML, TOML, XML and CSV data from the command line using a simple selector syntax.
+- [wttr.in](https://github.com/chubin/wttr.in) – Curl-friendly weather forecast service; run `curl wttr.in` for an instant report.
+
 ## ☁️🛠️ Web Services & Self-Hosted Platforms
 
 ### 🚀🔄 Platform-as-a-Service & App Deployment
@@ -38,6 +53,20 @@
 
 ### 🧾🔄 File Conversion & Processing
 - [VERT.sh](https://vert.sh/) – Privacy-focused, open-source web app for converting images, audio, video and documents. All non-video conversions run client-side (no upload), while videos use fast servers; no ads or size limits.
+
+### 🏠🔌 Home Automation
+- [Gladys Assistant](https://gladysassistant.com/) – Privacy-first open-source home assistant you can self-host to control smart devices and automate routines.
+- [Frigate](https://github.com/blakeblackshear/frigate) – Local NVR for Home Assistant with real-time object detection using TensorFlow and OpenCV.
+
+### 💻📂 Git Hosting
+- [soft-serve](https://github.com/charmbracelet/soft-serve) – Minimal Git server you operate from the command line, offering a simple TUI for browsing repositories.
+- [Gitea](https://gitea.io/en-us/) – Lightweight community-managed alternative to GitHub for running your own code hosting platform.
+- [gogs](https://gogs.io/) – Compact Go-based Git service that runs on low-resource servers with a familiar web interface.
+
+### 🔗🛠️ Developer Tools
+- [curlconverter](https://curlconverter.com/) – Converts `curl` commands into code snippets for languages like Python, JavaScript and Go.
+- [BookStack](https://www.bookstackapp.com/) – Self-hosted wiki and knowledge base platform for organising documentation.
+- [rss-proxy](https://github.com/damoeb/rss-proxy) – Generate RSS or Atom feeds for almost any website by analyzing its static HTML structure.
 
 ### 🏛️📊 Transparency & Monitoring
 - [Capitol Trades](https://www.capitoltrades.com/) – Free platform tracking U.S. Congress stock transactions. Browse and filter members’ buy/sell history by party, committee or issuer, and view aggregated charts of recent trading volume to spot potential conflicts of interest.
@@ -85,3 +114,6 @@
 
 ### 💻🖥️ JavaScript Components
 - [Xterm.js](https://xtermjs.org/) – Browser-based terminal emulator powering web apps like VS Code.
+
+### 🌍🗣️ Natural Language Processing
+- [argos-translate](https://github.com/argosopentech/argos-translate) – Offline machine translation library written in Python.


### PR DESCRIPTION
## Summary
- process initial batch of unprocessed blog posts
- record processed files in TODO.md
- catalog CLI utilities like wgcf, bombardier, dasel and wttr.in
- catalog desktop apps: drawio-desktop, far2l, MarkText
- catalog self-hosted platforms and tools: soft-serve, Gitea, gogs, curlconverter, BookStack, rss-proxy, Gladys Assistant, Frigate
- add argos-translate library entry

## Testing
- `npm run typecheck` *(fails: Cannot find module '@docusaurus/useBaseUrl' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685f630c67788328bcca69918c312dfe