### PR TITLE
Add batch of software links

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -33,16 +33,16 @@ blog/<file.md>
 - [x] 2022-12-28-links-from-my-inbox.md
 - [x] 2023-02-02-links-from-my-inbox.md
 - [x] 2023-02-12-links-from-my-inbox.md
-- [ ] 2023-02-22-links-from-my-inbox.md
-- [ ] 2023-03-11-links-from-my-inbox.md
-- [ ] 2023-03-25-links-from-my-inbox.md
-- [ ] 2023-04-13-links-from-my-inbox.md
-- [ ] 2023-05-19-links-from-my-inbox.md
-- [ ] 2023-05-21-links-from-my-inbox.md
-- [ ] 2023-05-28-links-from-my-inbox.md
-- [ ] 2023-06-08-links-from-my-inbox.md
-- [ ] 2023-06-28-links-from-my-inbox.md
-- [ ] 2023-08-01-links-from-my-inbox.md
+- [x] 2023-02-22-links-from-my-inbox.md
+- [x] 2023-03-11-links-from-my-inbox.md
+- [x] 2023-03-25-links-from-my-inbox.md
+- [x] 2023-04-13-links-from-my-inbox.md
+- [x] 2023-05-19-links-from-my-inbox.md
+- [x] 2023-05-21-links-from-my-inbox.md
+- [x] 2023-05-28-links-from-my-inbox.md
+- [x] 2023-06-08-links-from-my-inbox.md
+- [x] 2023-06-28-links-from-my-inbox.md
+- [x] 2023-08-01-links-from-my-inbox.md
 - [ ] 2023-08-04-links-from-my-inbox.md
 - [ ] 2023-08-05-links-from-my-inbox.md
 - [ ] 2023-08-13-links-from-my-inbox.md

--- a/software.md
+++ b/software.md
@@ -6,6 +6,7 @@
 
 ### 📚 Documentation Tools
 - [tldr pages](https://tldr.sh/) – Community-maintained, concise cheat-sheets for over 200 Unix commands, providing brief examples and options to speed up your shell workflow without consulting lengthy man pages.
+- [Vale](https://vale.sh/) – Command-line style checker ensuring consistent documentation.
 
 ## 🧩💻 Desktop Applications
 
@@ -21,6 +22,8 @@
 - [Org mode](https://orgmode.org/) – Plain-text productivity system for Emacs with outlines and agenda.
 - [Plan](https://getplan.co/) – Aggregates calendars and tasks from multiple services into one dashboard.
 - [ScriptKit](https://www.scriptkit.com/) – Open-source toolkit to launch scripts and automate developer workflows.
+- [AppFlowy](https://www.appflowy.com/) – Open-source workspace alternative to Notion with local data storage.
+- [espanso](https://espanso.org/) – Cross-platform text expander that replaces typed keywords with snippets.
 
 ### 🔧🔌 API Clients
 - [Yaak](https://yaak.app/) – Fast, offline-first, Git-friendly API client for REST, GraphQL, WebSocket, SSE and gRPC endpoints. Store requests as plain-text files for version control, encrypt secrets locally, and replay or share them from a desktop GUI.
@@ -34,9 +37,14 @@
 ### 🖥️💻 Virtualization
 - [Docker-OSX](https://github.com/sickcodes/Docker-OSX) – Run macOS in a Docker container using KVM for near-native performance.
 - [far2l](https://github.com/elfmz/far2l) – Modernized port of the classic FAR Manager with terminal and GUI interfaces for Linux and macOS.
+### 💾 Legacy Software Ports
+- [123elf](https://github.com/taviso/123elf) – Native Linux port of Lotus 1-2-3 spreadsheet classic.
 ### 📝 Markdown Editors
+
 - [MarkText](https://github.com/marktext/marktext) – Cross-platform Markdown editor with live preview and minimal UI, built on Electron.
 - [Markably](https://app.markably.io/) – Web-based Markdown editor with live preview and distraction-free mode.
+- [Zettlr](https://www.zettlr.com/) – Cross-platform Markdown editor geared toward academic writing.
+- [ghostwriter](https://ghostwriter.kde.org/) – Minimalist Markdown editor with focus mode and live preview.
 
 ### 🎛️ Audio Tools
 - [Soundux](https://github.com/Soundux/Soundux) – Cross-platform soundboard routing audio to specific applications.
@@ -47,6 +55,14 @@
 - [wttr.in](https://github.com/chubin/wttr.in) – Curl-friendly weather forecast service; run `curl wttr.in` for an instant report.
 - [Matterbridge](https://github.com/42wim/matterbridge) – Bridges messages between Slack, Discord, Matrix and other chat platforms via a single binary.
 - [sharing](https://github.com/parvardegr/sharing) – Simple CLI to share files or directories over HTTP for quick transfer to mobile devices.
+
+### 🛡️ Security Tools
+- [Snort](https://www.snort.org/) – Open-source network intrusion detection and prevention system.
+### 🗃️ Data Processing Tools
+- [Miller](https://github.com/johnkerl/miller) – Command-line Swiss army knife for CSV, TSV and JSON data manipulation.
+- [fastgron](https://github.com/adamritter/fastgron) – High-performance JSON to GRON converter built with simdjson.
+- [fq](https://github.com/wader/fq) – Binary data processor combining jq, hexdump and dd functionality.
+
 
 ### 🗜️ Compression Tools
 ### 📈🔬 Profiling & Benchmarking
@@ -65,13 +81,23 @@
 ### 🪟🤖 OS Automation Tools
 - [Generate autounattend.xml files for Windows 10/11](https://schneegans.de/windows/unattend-generator/) – Web service that guides you through selecting Windows Setup settings (partitions, locale, user accounts, drivers) and outputs a complete `autounattend.xml` file to automate clean installations on Windows 10/11.
 
+- [LibreAutomate](https://github.com/qgindi/LibreAutomate) – Windows automation tool and C# scripting environment.
 ### 🧾🔄 File Conversion & Processing
+- [Rembg](https://github.com/danielgatis/rembg) – Command-line tool to remove image backgrounds using machine learning.
+- [UpScayl](https://github.com/upscayl/upscayl) – Free AI-powered image upscaler for Windows, macOS and Linux.
+- [BackgroundRemover](https://github.com/nadermx/backgroundremover) – Python CLI to strip backgrounds from photos and videos.
+
 ### 🎞️ Video Editing
 - [LosslessCut](https://mifi.no/losslesscut/) – Simple cross-platform tool for quick, lossless trimming of video and audio files.
 - [VERT.sh](https://vert.sh/) – Privacy-focused, open-source web app for converting images, audio, video and documents. All non-video conversions run client-side (no upload), while videos use fast servers; no ads or size limits.
 - [Squoosh](https://squoosh.app/) – Progressive web app that compresses images locally in the browser using modern codecs.
 ### 📰 RSS & Feed Readers
 - [FreshRSS](https://freshrss.org/) – Lightweight self-hosted aggregator for RSS and Atom feeds.
+
+- [TT-RSS](https://tt-rss.org/) – Web-based news feed aggregator you can self-host.
+- [Fluent Reader](https://github.com/yang991178/fluent-reader) – Modern cross-platform RSS reader for desktops.
+- [Stringer](https://github.com/stringer-rss/stringer) – Self-hosted, anti-social RSS reader built on Ruby on Rails.
+- [CommaFeed](https://github.com/Athou/commafeed) – Google Reader inspired self-hosted feed reader with multiple layouts.
 
 ### 🏠🔌 Home Automation
 - [Gladys Assistant](https://gladysassistant.com/) – Privacy-first open-source home assistant for controlling smart devices.
@@ -97,6 +123,7 @@
 - [slidehero.ai](https://www.slidehero.ai/) – AI-powered slide generator: paste your outline or bullet points and instantly produce formatted PowerPoint or Google Slides decks with layouts and graphics tailored to your content.
 - [imaginAIry](https://github.com/brycedrennan/imaginAIry) – Python tool for generating images with Stable Diffusion from the command line.
 - [Riffusion](https://www.riffusion.com/about) – Creates music by running Stable Diffusion on spectrograms; open source at [riffusion/riffusion](https://github.com/riffusion/riffusion).
+- [PrivateGPT](https://github.com/imartinez/privateGPT) – Run GPT-based question answering locally on your documents with no Internet required.
 
 ## 🌐🧩 Browser Extensions & Tools
 
@@ -117,6 +144,7 @@
 ### 🧱 3D Modeling Tools
 - [DSLCad](https://github.com/DSchroer/dslcad) – Lightweight language and interpreter for building 3D models.
 
+- [Sweet Home 3D](https://www.sweethome3d.com/) – Free interior design application for drawing house plans and arranging furniture in 3D.
 ### 🗃️🔎 Database Tools
 - [SQLite File Format Viewer](https://sqlite-internal.pages.dev/#page=10) – Web-based tool for inspecting SQLite database internals. Upload a `.sqlite` file or use a demo DB to explore page structures, B-tree layouts, freelist pages and WAL entries via clickable diagrams.
 
@@ -129,12 +157,19 @@
 - [webcamize](https://github.com/cowtoolz/webcamize) – CLI tool letting you use DSLRs, mirrorless cameras, camcorders or smartphones as Linux webcams. Configures UVC drivers and handles firmware quirks so professional cameras appear as `/dev/video*` devices.
 - [matrix-webcam](https://github.com/joschuck/matrix-webcam) – Adds Matrix-style green code rain effect to your webcam feed for video calls.
 
+### 📱 Mobile Utilities
+- [scrcpy](https://github.com/Genymobile/scrcpy) – Mirror and control Android devices from your computer via USB or Wi-Fi.
+- [display-switch](https://github.com/haimgel/display-switch) – Switch monitor inputs automatically when a USB device connects.
 ## 🧠🧰 Development Environments
 
 ### 🧩🧵 Moldable IDEs
+
 - [Glamorous Toolkit](https://gtoolkit.com/) – Interactive, moldable IDE built on Pharo Smalltalk and JavaScript runtimes. Offers real-time object inspectors, context-aware micro-tools and live code modification to explore and evolve applications without stopping execution.
 
+### 🛠️ Programming Languages & Compilers
+- [SectorC](https://github.com/xorvoid/sectorc) – 512-byte x86 boot sector C compiler written in assembly.
 ## 🗄️🛢️ Database Engines
+
 - [DuckDB](https://github.com/duckdb/duckdb) – In-process analytical SQL database optimized for fast local queries without a server.
 
 ## 📚🛠️ Libraries & Frameworks
@@ -148,6 +183,13 @@
 - [PortAudio](https://github.com/PortAudio/portaudio) – Cross-platform library for real-time audio input and output.
 - [argos-translate](https://github.com/argosopentech/argos-translate) – Offline machine translation library written in Python.
 
+### ⚙️ C++ Libraries
+- [spdlog](https://github.com/gabime/spdlog) – Fast C++ logging library with a simple API.
+- [fmt](https://github.com/fmtlib/fmt) – Modern formatting library for C++.
+- [RxCpp](https://github.com/ReactiveX/RxCpp) – Reactive Extensions for composing asynchronous event streams.
+- [simdjson](https://github.com/simdjson/simdjson) – SIMD-accelerated JSON parser achieving gigabytes per second.
+
 ## 🎮 Games & Emulators
+
 - [webrcade](https://github.com/webrcade/webrcade) – Feed-driven retro gaming platform that runs classic games in the browser.
 - [Genesis-Plus-GX](https://github.com/ekeeke/Genesis-Plus-GX) – Accurate and portable Sega 8/16‑bit emulator.


### PR DESCRIPTION
## Summary
- append new software entries including Rembg, AppFlowy, scrcpy and more
- categorize tools under appropriate headings
- mark first ten inbox posts as processed

## Testing
- `npm run typecheck` *(fails: Cannot find module '@docusaurus/...')*

------
https://chatgpt.com/codex/tasks/task_e_685f7037409c8328beef301f1a5bd82c